### PR TITLE
Explicit indication of type and sign

### DIFF
--- a/src/hpma115S0.cpp
+++ b/src/hpma115S0.cpp
@@ -45,7 +45,7 @@ void HPMA115S0::Init() {
  * @param size of buffer
  * @return  void
  */
-void HPMA115S0::SendCmd(char * cmdBuf, unsigned int cmdSize) {
+void HPMA115S0::SendCmd(uint8_t * cmdBuf, unsigned int cmdSize) {
   //Clear RX
   while (_serial.available())
     _serial.read();
@@ -114,7 +114,7 @@ int HPMA115S0::ReadCmdResp(char * dataBuf, unsigned int dataBufSize, unsigned in
  * @return  returns true if valid measurements were read from sensor
  */
 boolean HPMA115S0::ReadParticleMeasurement(unsigned int * pm2_5, unsigned int * pm10) {
-  char cmdBuf[] = {0x68, 0x01, 0x04, 0x93};
+  uint8_t cmdBuf[] = {0x68, 0x01, 0x04, 0x93};
   char dataBuf[HPM_READ_PARTICLE_MEASURMENT_LEN - 1];
 
   //Serial.println("PS- Reading Particle Measurements..." );
@@ -140,7 +140,7 @@ boolean HPMA115S0::ReadParticleMeasurement(unsigned int * pm2_5, unsigned int * 
  * @return  void
  */
 void HPMA115S0::StartParticleMeasurement() {
-  char cmd[] = {0x68, 0x01, 0x01, 0x96};
+  uint8_t cmd[] = {0x68, 0x01, 0x01, 0x96};
   SendCmd(cmd, 4);
 }
 
@@ -149,7 +149,7 @@ void HPMA115S0::StartParticleMeasurement() {
  * @return  void
  */
 void HPMA115S0::StopParticleMeasurement() {
-  char cmd[] = {0x68, 0x01, 0x02, 0x95};
+  uint8_t cmd[] = {0x68, 0x01, 0x02, 0x95};
   SendCmd(cmd, 4);
 }
 
@@ -158,7 +158,7 @@ void HPMA115S0::StopParticleMeasurement() {
  * @return  void
  */
 void HPMA115S0::EnableAutoSend() {
-  char cmd[] = {0x68, 0x01, 0x40, 0x57};
+  uint8_t cmd[] = {0x68, 0x01, 0x40, 0x57};
   SendCmd(cmd, 4);
 }
 
@@ -167,7 +167,7 @@ void HPMA115S0::EnableAutoSend() {
  * @return  void
  */
 void HPMA115S0::DisableAutoSend() {
-  char cmd[] = {0x68, 0x01, 0x20, 0x77};
+  uint8_t cmd[] = {0x68, 0x01, 0x20, 0x77};
   SendCmd(cmd, 4);
 }
 

--- a/src/hpma115S0.h
+++ b/src/hpma115S0.h
@@ -11,6 +11,7 @@
 #define HPMA115S0_H
 
 #include "Arduino.h"
+#include <stdint.h>
 
 #define HPM_CMD_RESP_HEAD 0x40
 #define HPM_MAX_RESP_SIZE 8 // max command response size is 8 bytes
@@ -108,7 +109,7 @@ private:
      * @param size of buffer
      * @return  void
      */
-    void SendCmd(char * command, unsigned int size);
+    void SendCmd(uint8_t * command, unsigned int size);
 
     /**
     * @brief Function that reads command response from sensor


### PR DESCRIPTION
PlatformIO CI is not allowing compiling the warning

```
.piolibdeps/HPMA115S0 Arduino Library/src/hpma115S0.cpp: In member function 'boolean HPMA115S0::ReadParticleMeasurement(unsigned int*, unsigned int*)':

.piolibdeps/HPMA115S0 Arduino Library/src/hpma115S0.cpp:117:42: error: narrowing conversion of '147' from 'int' to 'char' inside { } [-Wnarrowing]
char cmdBuf[] = {0x68, 0x01, 0x04, 0x93};
^
```

So i've decided to use std int library to fix it